### PR TITLE
Align SEO metadata with visible content and indexable pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 Version identifiers match the application `assetVersion`.
 
+## 20260712a - 2026-07-12
+
+### Changed
+- Use accurate sitemap modification dates and omit unsupported priority and change-frequency hints.
+- Replace About page FAQ structured data with structured data that matches its visible content.
+- Make localized memo creation pages indexable and add privacy details for search visitors.
+
 ## 20260628a - 2026-06-28
 
 ### Baseline

--- a/internal/frontend/generated/pages/en/create-memo.html
+++ b/internal/frontend/generated/pages/en/create-memo.html
@@ -203,6 +203,28 @@
                 <div id="statusMessage" class="message"></div>
             </div>
         </div>
+
+        <section class="info-section" aria-labelledby="create-privacy-title">
+            <h2 id="create-privacy-title">What makes it private</h2>
+            <div class="info-grid">
+                <div class="info-card">
+                    <h3>Encrypted in your browser</h3>
+                    <p>Your memo is encrypted with AES-256-GCM before it leaves your device. We only store ciphertext.</p>
+                </div>
+                <div class="info-card">
+                    <h3>Passwords stay on your device</h3>
+                    <p>The encryption password is generated in your browser. It's never sent to or stored on our servers.</p>
+                </div>
+                <div class="info-card">
+                    <h3>Deleted after read or expiry</h3>
+                    <p>After a successful read, the browser confirms deletion with the server. Expired memos are cleaned up automatically.</p>
+                </div>
+                <div class="info-card">
+                    <h3>No accounts, no tracking</h3>
+                    <p>You don't need to sign up. We don't use cookies, advertising trackers, third-party analytics, or behavioral profiling. We keep only limited aggregate operational metrics needed to run and protect the service.</p>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer class="footer">

--- a/internal/server/seo.go
+++ b/internal/server/seo.go
@@ -43,7 +43,8 @@ var seoPages = map[string]seoPage{
 		TwitterDesc: "page.about.twitterDescription",
 		Keywords:    "page.about.keywords",
 		Hreflang:    true,
-		Schema:      "faq",
+		Schema:      "about",
+		PageName:    "about.hero.title",
 	},
 	"/create-memo.html": {
 		Prefix:      "create",
@@ -52,7 +53,7 @@ var seoPages = map[string]seoPage{
 		OGDesc:      "create.hero.ogDescription",
 		TwitterDesc: "create.hero.twitterDescription",
 		Keywords:    "page.create.keywords",
-		NoIndex:     true,
+		Hreflang:    true,
 		Schema:      "softwarePage",
 		PageName:    "create.hero.title",
 		Breadcrumb:  "create.hero.title",
@@ -232,8 +233,8 @@ func buildJSONLD(page seoPage, locale, pathWithoutLocale, publicOrigin, canonica
 	switch page.Schema {
 	case "app":
 		data = appJSONLD(locale, canonical, description)
-	case "faq":
-		data = faqJSONLD(locale)
+	case "about":
+		data = aboutJSONLD(page, locale, canonical, description)
 	case "softwarePage":
 		data = softwarePageJSONLD(page, locale, pathWithoutLocale, publicOrigin, canonical, description)
 	case "creativeWork":
@@ -289,30 +290,14 @@ func appJSONLD(locale, canonical, description string) map[string]interface{} {
 	}
 }
 
-func faqJSONLD(locale string) map[string]interface{} {
+func aboutJSONLD(page seoPage, locale, canonical, description string) map[string]interface{} {
 	return map[string]interface{}{
-		"@context":   "https://schema.org",
-		"@type":      "FAQPage",
-		"inLanguage": hreflangCode(locale),
-		"mainEntity": []map[string]interface{}{
-			faqItem(locale, "faq.privacy.question", "faq.privacy.answer"),
-			faqItem(locale, "faq.encryption.question", "faq.encryption.answer"),
-			faqItem(locale, "faq.duration.question", "faq.duration.answer"),
-			faqItem(locale, "faq.recovery.question", "faq.recovery.answer"),
-			faqItem(locale, "faq.cost.question", "faq.cost.answer"),
-			faqItem(locale, "faq.technology.question", "faq.technology.answer"),
-		},
-	}
-}
-
-func faqItem(locale, questionKey, answerKey string) map[string]interface{} {
-	return map[string]interface{}{
-		"@type": "Question",
-		"name":  tr(locale, questionKey),
-		"acceptedAnswer": map[string]string{
-			"@type": "Answer",
-			"text":  tr(locale, answerKey),
-		},
+		"@context":    "https://schema.org",
+		"@type":       "AboutPage",
+		"name":        tr(locale, page.PageName),
+		"description": description,
+		"url":         canonical,
+		"inLanguage":  hreflangCode(locale),
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,7 @@ import (
 	"github.com/timoheimonen/securememo/internal/store"
 )
 
-const assetVersion = "20260628a"
+const assetVersion = "20260712a"
 
 var clientLocalizationAssetRe = regexp.MustCompile(`^/js/clientLocalization\.([A-Za-z0-9_-]+)\.js$`)
 
@@ -231,10 +231,8 @@ func (s *Server) serveSitemap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	type urlEntry struct {
-		Loc        string `xml:"loc"`
-		LastMod    string `xml:"lastmod"`
-		ChangeFreq string `xml:"changefreq"`
-		Priority   string `xml:"priority"`
+		Loc     string `xml:"loc"`
+		LastMod string `xml:"lastmod"`
 	}
 	type urlSet struct {
 		XMLName xml.Name   `xml:"urlset"`
@@ -242,22 +240,19 @@ func (s *Server) serveSitemap(w http.ResponseWriter, r *http.Request) {
 		URLs    []urlEntry `xml:"url"`
 	}
 	pages := []struct {
-		path       string
-		priority   string
-		changeFreq string
+		path    string
+		lastMod string
 	}{
-		{"", "1.0", "weekly"},
-		{"/about.html", "0.8", "monthly"},
+		{"", "2026-06-27"},
+		{"/about.html", "2026-07-12"},
+		{"/create-memo.html", "2026-07-12"},
 	}
-	now := time.Now().UTC().Format("2006-01-02")
 	var entries []urlEntry
 	for _, page := range pages {
 		for _, locale := range supportedLocales {
 			entries = append(entries, urlEntry{
-				Loc:        fmt.Sprintf("%s/%s%s", s.cfg.PublicOrigin, locale, page.path),
-				LastMod:    now,
-				ChangeFreq: page.changeFreq,
-				Priority:   page.priority,
+				Loc:     fmt.Sprintf("%s/%s%s", s.cfg.PublicOrigin, locale, page.path),
+				LastMod: page.lastMod,
 			})
 		}
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -72,7 +72,7 @@ func TestRenderedSEOHeadUsesLocalizedMetadata(t *testing.T) {
 
 func TestNoIndexPagesAreMarkedButCrawlable(t *testing.T) {
 	app := newTestServer(t)
-	for _, path := range []string{"/en/create-memo.html", "/en/read-memo.html", "/en/revoke-memo.html", "/en/tos.html", "/en/privacy.html"} {
+	for _, path := range []string{"/en/read-memo.html", "/en/revoke-memo.html", "/en/tos.html", "/en/privacy.html"} {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 
@@ -87,6 +87,52 @@ func TestNoIndexPagesAreMarkedButCrawlable(t *testing.T) {
 	}
 }
 
+func TestCreateMemoPageIsIndexableAndLocalized(t *testing.T) {
+	app := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/fi/create-memo.html", nil)
+
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /fi/create-memo.html status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `<meta name="robots" content="noindex,follow">`) {
+		t.Fatal("localized create page is marked noindex")
+	}
+	for _, want := range []string{
+		`<link rel="canonical" href="https://securememo.app/fi/create-memo.html">`,
+		`hreflang="fi" href="https://securememo.app/fi/create-memo.html"`,
+		`hreflang="x-default" href="https://securememo.app/en/create-memo.html"`,
+		`<h2 id="create-privacy-title">Mikä tekee siitä yksityisen</h2>`,
+		`<h3>Salattu selaimessasi</h3>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("localized create page missing %q", want)
+		}
+	}
+}
+
+func TestAboutStructuredDataMatchesVisiblePageType(t *testing.T) {
+	app := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/en/about.html", nil)
+
+	app.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /en/about.html status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"@type": "FAQPage"`) {
+		t.Fatal("about page contains FAQ structured data without a visible FAQ")
+	}
+	if !strings.Contains(body, `"@type": "AboutPage"`) {
+		t.Fatal("about page missing AboutPage structured data")
+	}
+}
+
 func TestSitemapOnlyIncludesIndexablePages(t *testing.T) {
 	app := newTestServer(t)
 	rec := httptest.NewRecorder()
@@ -98,15 +144,22 @@ func TestSitemapOnlyIncludesIndexablePages(t *testing.T) {
 		t.Fatalf("GET /sitemap.xml status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	for _, path := range []string{"/create-memo.html", "/read-memo.html", "/revoke-memo.html", "/tos.html", "/privacy.html"} {
+	for _, path := range []string{"/read-memo.html", "/revoke-memo.html", "/tos.html", "/privacy.html"} {
 		if strings.Contains(body, path) {
 			t.Fatalf("sitemap includes noindex page %s", path)
 		}
 	}
-	for _, path := range []string{"https://securememo.app/en", "https://securememo.app/en/about.html"} {
-		if !strings.Contains(body, path) {
-			t.Fatalf("sitemap missing indexable page %s", path)
+	for _, entry := range []string{
+		"<loc>https://securememo.app/en</loc>\n    <lastmod>2026-06-27</lastmod>",
+		"<loc>https://securememo.app/en/about.html</loc>\n    <lastmod>2026-07-12</lastmod>",
+		"<loc>https://securememo.app/en/create-memo.html</loc>\n    <lastmod>2026-07-12</lastmod>",
+	} {
+		if !strings.Contains(body, entry) {
+			t.Fatalf("sitemap missing indexable entry %q", entry)
 		}
+	}
+	if strings.Contains(body, "<changefreq>") || strings.Contains(body, "<priority>") {
+		t.Fatal("sitemap includes ignored changefreq or priority hints")
 	}
 }
 


### PR DESCRIPTION
## 20260712a - 2026-07-12

### Changed
- Use accurate sitemap modification dates and omit unsupported priority and change-frequency hints.
- Replace About page FAQ structured data with structured data that matches its visible content.
- Make localized memo creation pages indexable and add privacy details for search visitors.
