### PR TITLE
Harden secret forms against native fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 Version identifiers match the application `assetVersion`.
 
+## 20260713a - 2026-07-13
+
+### Security
+- Make browser-only memo and password forms fail closed until their local encryption or decryption handlers are ready.
+- Prevent native form fallback from serializing memo plaintext or decryption passwords into request URLs.
+
 ## 20260712a - 2026-07-12
 
 ### Changed

--- a/internal/frontend/generated/js/create-memo.js
+++ b/internal/frontend/generated/js/create-memo.js
@@ -1,14 +1,3 @@
-function initializePage() {
-  hideElement('result');
-  showElement('memoForm');
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializePage);
-} else {
-  initializePage();
-}
-
 function generatePassword() {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   const passwordLength = 32;
@@ -191,7 +180,7 @@ async function encryptMemo(message) {
   }
 }
 
-document.getElementById('memoForm').addEventListener('submit', async (e) => {
+async function handleCreateSubmit(e) {
   e.preventDefault();
   const resultSection = document.getElementById('result');
   if (resultSection && !resultSection.classList.contains('hidden')) {
@@ -254,7 +243,7 @@ document.getElementById('memoForm').addEventListener('submit', async (e) => {
     submitButton.textContent = t('btn.create');
     hideElement('loadingIndicator');
   }
-});
+}
 
 document.getElementById('copyUrl').addEventListener('click', async () => {
   const urlInput = document.getElementById('memoUrl');
@@ -364,4 +353,37 @@ function showMessage(message, type) {
 
 function showTranslatedMessage(key, type) {
   showMessage(t(key), type);
+}
+
+function hasRequiredCreateCapabilities() {
+  return typeof globalThis.fetch === 'function' &&
+    typeof globalThis.TextEncoder === 'function' &&
+    typeof globalThis.btoa === 'function' &&
+    globalThis.crypto &&
+    typeof globalThis.crypto.getRandomValues === 'function' &&
+    globalThis.crypto.subtle &&
+    globalThis.MemoCryptoConfig &&
+    typeof globalThis.MemoCryptoConfig.getCurrentVersion === 'function';
+}
+
+function initializeCreatePage() {
+  hideElement('result');
+  showElement('memoForm');
+
+  const memoForm = document.getElementById('memoForm');
+  const memoFormControls = document.getElementById('memoFormControls');
+  if (!memoForm || !memoFormControls || !hasRequiredCreateCapabilities()) {
+    return;
+  }
+
+  memoForm.addEventListener('submit', handleCreateSubmit);
+  memoFormControls.disabled = false;
+  memoForm.setAttribute('aria-busy', 'false');
+  hideElement('memoFormStatus');
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeCreatePage, { once: true });
+} else {
+  initializeCreatePage();
 }

--- a/internal/frontend/generated/js/read-memo.js
+++ b/internal/frontend/generated/js/read-memo.js
@@ -139,166 +139,199 @@ function initializePage() {
   hideElement('statusMessage');
 }
 
-window.addEventListener('load', () => {
-  initializePage();
+async function handleDecryptSubmit(e) {
+  e.preventDefault();
+  const password = document.getElementById('password').value.trim();
   const memoId = getMemoId();
-  if (!memoId) {
-    showError(t('error.missingMemoId'));
+  if (!password) {
+    showError(t('error.missingPassword'));
     return;
   }
-  const decryptForm = document.getElementById('decryptForm');
-  if (decryptForm) {
-    decryptForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const password = document.getElementById('password').value.trim();
-      const memoId = getMemoId();
-      if (!password) {
-        showError(t('error.missingPassword'));
-        return;
-      }
-      if (!memoId) {
-        showError(t('error.invalidMemoUrl'));
-        return;
-      }
-      const decryptButton = document.getElementById('decryptButton');
-      const decryptLoadingIndicator = document.getElementById('decryptLoadingIndicator');
-      if (decryptButton) {
-        decryptButton.disabled = true;
-        decryptButton.textContent = t('btn.decrypting');
-      }
-      if (decryptLoadingIndicator) {
-        showElement('decryptLoadingIndicator');
-      }
+  if (!memoId) {
+    showError(t('error.invalidMemoUrl'));
+    return;
+  }
+  const decryptButton = document.getElementById('decryptButton');
+  const decryptLoadingIndicator = document.getElementById('decryptLoadingIndicator');
+  if (decryptButton) {
+    decryptButton.disabled = true;
+    decryptButton.textContent = t('btn.decrypting');
+  }
+  if (decryptLoadingIndicator) {
+    showElement('decryptLoadingIndicator');
+  }
+  try {
+    const requestBody = {};
+    const readParams = new URLSearchParams({ id: memoId });
+    const response = await fetch('/api/read-memo?' + readParams.toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody)
+    });
+    if (response.status === 429) {
+      showError(t('msg.tooManyRequests'));
+      return;
+    }
+    const result = await response.json();
+    if (response.ok) {
+      const decryptedMessage = await decryptMemo(result.encryptedMessage, password);
+      let decryptedPayload;
       try {
-        const requestBody = {};
-        const readParams = new URLSearchParams({ id: memoId });
-        const response = await fetch('/api/read-memo?' + readParams.toString(), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody)
-        });
-        if (response.status === 429) {
-          showError(t('msg.tooManyRequests'));
-          return;
+        decryptedPayload = JSON.parse(decryptedMessage);
+        if (typeof decryptedPayload.message !== 'string' || (result.requiresDeletionToken && !decryptedPayload.deletionToken)) {
+          throw new Error();
         }
-        const result = await response.json();
-        if (response.ok) {
-          const decryptedMessage = await decryptMemo(result.encryptedMessage, password);
-          let decryptedPayload;
-          try {
-            decryptedPayload = JSON.parse(decryptedMessage);
-            if (typeof decryptedPayload.message !== 'string' || (result.requiresDeletionToken && !decryptedPayload.deletionToken)) {
-              throw new Error();
-            }
-          } catch {
-            decryptedPayload = { message: decryptedMessage };
+      } catch {
+        decryptedPayload = { message: decryptedMessage };
+      }
+      document.getElementById('decryptedMessage').textContent = decryptedPayload.message;
+      showElement('memoContent');
+      hideElement('passwordForm');
+      const memoStatus = document.getElementById('memoStatus');
+      const deletionSpinner = document.getElementById('deletionSpinner');
+      if (memoStatus) {
+        memoStatus.textContent = t('msg.memoDecrypted');
+      }
+      if (deletionSpinner) {
+        showElement('deletionSpinner');
+      }
+      document.getElementById('password').value = '';
+      const errorContent = document.getElementById('errorContent');
+      const statusMessage = document.getElementById('statusMessage');
+      if (errorContent) hideElement('errorContent');
+      if (statusMessage) hideElement('statusMessage');
+      const deleteBody = {};
+      if (!decryptedPayload.deletionToken) {
+        throw new Error('Missing deletion token in payload');
+      }
+      deleteBody.deletionToken = decryptedPayload.deletionToken;
+      deleteBody.memoId = memoId;
+      const maxAttempts = 3;
+      const delayMs = 3000;
+      let deleteResponse;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          deleteResponse = await fetch('/api/confirm-delete', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(deleteBody)
+          });
+          if (deleteResponse.ok || [429, 403, 404].includes(deleteResponse.status)) {
+            break;
           }
-          document.getElementById('decryptedMessage').textContent = decryptedPayload.message;
-          showElement('memoContent');
-          hideElement('passwordForm');
-          const memoStatus = document.getElementById('memoStatus');
-          const deletionSpinner = document.getElementById('deletionSpinner');
-          if (memoStatus) {
-            memoStatus.textContent = t('msg.memoDecrypted');
-          }
-          if (deletionSpinner) {
-            showElement('deletionSpinner');
-          }
-          document.getElementById('password').value = '';
-          if (errorContent) hideElement('errorContent');
-          if (statusMessage) hideElement('statusMessage');
-          const deleteBody = {};
-          if (!decryptedPayload.deletionToken) {
-            throw new Error('Missing deletion token in payload');
-          }
-          deleteBody.deletionToken = decryptedPayload.deletionToken;
-          deleteBody.memoId = memoId;
-          const maxAttempts = 3;
-          const delayMs = 3000;
-          let deleteResponse;
-          for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            try {
-              deleteResponse = await fetch('/api/confirm-delete', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(deleteBody)
-              });
-              if (deleteResponse.ok || [429, 403, 404].includes(deleteResponse.status)) {
-                break;
-              }
-            } catch (e) {
-            }
-            if (attempt < maxAttempts) {
-              await new Promise(res => setTimeout(res, delayMs));
-            }
-          }
-          if (deleteResponse && deleteResponse.status === 429) {
-            showMessage(t('msg.tooManyRequests'), 'error');
-            const deletionSpinner = document.getElementById('deletionSpinner');
-            if (deletionSpinner) {
-              hideElement('deletionSpinner');
-            }
-          } else if (deleteResponse && deleteResponse.ok) {
-            const memoStatus = document.getElementById('memoStatus');
-            const deletionSpinner = document.getElementById('deletionSpinner');
-            if (memoStatus) {
-              memoStatus.textContent = t('msg.memoDeleted');
-            }
-            if (deletionSpinner) {
-              hideElement('deletionSpinner');
-            }
-          } else {
-            showMessage(t('msg.deletionError'), 'warning');
-            const deletionSpinner = document.getElementById('deletionSpinner');
-            if (deletionSpinner) {
-              hideElement('deletionSpinner');
-            }
-          }
-        } else {
-          if (response.status === 429) {
-            showError(t('msg.tooManyRequests'));
-          } else if (result.error === 'Memo not found') {
-            showError(t('error.memoAlreadyRead'));
-          } else if (result.error === 'Memo expired') {
-            showError(t('error.memoExpired'));
-          } else {
-            showError(result.error || t('error.readMemoError'));
-          }
+        } catch (e) {
         }
-      } catch (error) {
-        if (error.message.includes('Failed to decrypt')) {
-          showError(t('error.invalidPassword'));
-        } else {
-          showError(t('error.readMemoError'));
-        }
-      } finally {
-        const decryptButton = document.getElementById('decryptButton');
-        const decryptLoadingIndicator = document.getElementById('decryptLoadingIndicator');
-        if (decryptButton) {
-          decryptButton.disabled = false;
-          decryptButton.textContent = t('btn.decrypt');
-        }
-        if (decryptLoadingIndicator) {
-          hideElement('decryptLoadingIndicator');
+        if (attempt < maxAttempts) {
+          await new Promise(res => setTimeout(res, delayMs));
         }
       }
-    });
-  }
-  const toggleReadPasswordBtn = document.getElementById('toggleReadPassword');
-  if (toggleReadPasswordBtn) {
-    toggleReadPasswordBtn.addEventListener('click', () => {
-      const passwordInput = document.getElementById('password');
-      const toggleBtn = document.getElementById('toggleReadPassword');
-      if (passwordInput.type === 'password') {
-        passwordInput.type = 'text';
-        toggleBtn.textContent = t('btn.hide');
+      if (deleteResponse && deleteResponse.status === 429) {
+        showMessage(t('msg.tooManyRequests'), 'error');
+        const deletionSpinner = document.getElementById('deletionSpinner');
+        if (deletionSpinner) {
+          hideElement('deletionSpinner');
+        }
+      } else if (deleteResponse && deleteResponse.ok) {
+        const memoStatus = document.getElementById('memoStatus');
+        const deletionSpinner = document.getElementById('deletionSpinner');
+        if (memoStatus) {
+          memoStatus.textContent = t('msg.memoDeleted');
+        }
+        if (deletionSpinner) {
+          hideElement('deletionSpinner');
+        }
       } else {
-        passwordInput.type = 'password';
-        toggleBtn.textContent = t('btn.show');
+        showMessage(t('msg.deletionError'), 'warning');
+        const deletionSpinner = document.getElementById('deletionSpinner');
+        if (deletionSpinner) {
+          hideElement('deletionSpinner');
+        }
       }
-    });
+    } else {
+      if (response.status === 429) {
+        showError(t('msg.tooManyRequests'));
+      } else if (result.error === 'Memo not found') {
+        showError(t('error.memoAlreadyRead'));
+      } else if (result.error === 'Memo expired') {
+        showError(t('error.memoExpired'));
+      } else {
+        showError(result.error || t('error.readMemoError'));
+      }
+    }
+  } catch (error) {
+    if (error.message.includes('Failed to decrypt')) {
+      showError(t('error.invalidPassword'));
+    } else {
+      showError(t('error.readMemoError'));
+    }
+  } finally {
+    const decryptButton = document.getElementById('decryptButton');
+    const decryptLoadingIndicator = document.getElementById('decryptLoadingIndicator');
+    if (decryptButton) {
+      decryptButton.disabled = false;
+      decryptButton.textContent = t('btn.decrypt');
+    }
+    if (decryptLoadingIndicator) {
+      hideElement('decryptLoadingIndicator');
+    }
   }
-});
+}
+
+function handleToggleReadPassword() {
+  const toggleReadPasswordBtn = document.getElementById('toggleReadPassword');
+  const passwordInput = document.getElementById('password');
+  if (!toggleReadPasswordBtn || !passwordInput) {
+    return;
+  }
+  if (passwordInput.type === 'password') {
+    passwordInput.type = 'text';
+    toggleReadPasswordBtn.textContent = t('btn.hide');
+  } else {
+    passwordInput.type = 'password';
+    toggleReadPasswordBtn.textContent = t('btn.show');
+  }
+}
+
+function hasRequiredReadCapabilities() {
+  return typeof globalThis.fetch === 'function' &&
+    typeof globalThis.TextEncoder === 'function' &&
+    typeof globalThis.TextDecoder === 'function' &&
+    typeof globalThis.atob === 'function' &&
+    globalThis.crypto &&
+    globalThis.crypto.subtle &&
+    globalThis.MemoCryptoConfig &&
+    typeof globalThis.MemoCryptoConfig.parseEncryptedMessage === 'function';
+}
+
+function initializeReadPage() {
+  initializePage();
+
+  const memoId = getMemoId();
+  if (!memoId) {
+    const errorMessage = document.getElementById('errorMessage');
+    showError(errorMessage ? errorMessage.textContent : t('error.missingMemoId'));
+    return;
+  }
+
+  const decryptForm = document.getElementById('decryptForm');
+  const decryptFormControls = document.getElementById('decryptFormControls');
+  const toggleReadPasswordBtn = document.getElementById('toggleReadPassword');
+  if (!decryptForm || !decryptFormControls || !toggleReadPasswordBtn || !hasRequiredReadCapabilities()) {
+    return;
+  }
+
+  decryptForm.addEventListener('submit', handleDecryptSubmit);
+  toggleReadPasswordBtn.addEventListener('click', handleToggleReadPassword);
+  decryptFormControls.disabled = false;
+  decryptForm.setAttribute('aria-busy', 'false');
+  hideElement('decryptFormStatus');
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeReadPage, { once: true });
+} else {
+  initializeReadPage();
+}
 
 function showError(message) {
   document.getElementById('errorMessage').textContent = message;

--- a/internal/frontend/generated/pages/en/create-memo.html
+++ b/internal/frontend/generated/pages/en/create-memo.html
@@ -130,26 +130,31 @@
                 <h1>Create Secure Memo</h1>
                 <p class="memo-description">Your memo will be encrypted in your browser and deleted after successful read confirmation or expiration.</p>
 
-                <form id="memoForm" class="memo-form">
-                    <div class="form-group">
-                        <label for="message">Your Memo</label>
-                        <textarea id="message" name="message" required
-                                  placeholder="Type your secret memo here..."
-                                  rows="8" maxlength="10000"></textarea>
-                        <small class="form-help">Maximum 10,000 characters</small>
-                    </div>
+                <form id="memoForm" class="memo-form" aria-busy="true" aria-describedby="memoFormStatus">
+                    <fieldset id="memoFormControls" class="sensitive-form-controls" disabled>
+                        <div class="form-group">
+                            <label for="message">Your Memo</label>
+                            <textarea id="message" required
+                                      placeholder="Type your secret memo here..."
+                                      rows="8" maxlength="10000"></textarea>
+                            <small class="form-help">Maximum 10,000 characters</small>
+                        </div>
 
-                    <div class="form-group">
-                        <label for="expiryHours">Expiry Time</label>
-                        <select id="expiryHours" name="expiryHours">
-                            <option value="8">Delete on read or 8 hours</option>
-                            <option value="24">Delete on read or 1 day</option>
-                            <option value="48">Delete on read or 2 days</option>
-                            <option value="168">Delete on read or 1 week</option>
-                            <option value="720">Delete on read or 30 days</option>
-                        </select>
-                    </div>
-                    <button type="submit" class="btn btn-primary" id="submitButton">Create Secure Memo</button>
+                        <div class="form-group">
+                            <label for="expiryHours">Expiry Time</label>
+                            <select id="expiryHours" name="expiryHours">
+                                <option value="8">Delete on read or 8 hours</option>
+                                <option value="24">Delete on read or 1 day</option>
+                                <option value="48">Delete on read or 2 days</option>
+                                <option value="168">Delete on read or 1 week</option>
+                                <option value="720">Delete on read or 30 days</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary" id="submitButton">Create Secure Memo</button>
+                    </fieldset>
+
+                    <p id="memoFormStatus" class="form-help" role="status">Loading...</p>
+                    <noscript><p class="form-help">Requires JavaScript. Requires HTML5.</p></noscript>
 
                     <div id="loadingIndicator" class="loading-spinner hidden">
                         <div class="spinner"></div>

--- a/internal/frontend/generated/pages/en/read-memo.html
+++ b/internal/frontend/generated/pages/en/read-memo.html
@@ -131,17 +131,22 @@
                 <p class="memo-description">Enter the password to decrypt and read the memo. The password should have been shared with you separately from the URL. The memo will be deleted after being read or expired.</p>
 
                 <div id="passwordForm" class="memo-form">
-                    <form id="decryptForm">
-                        <div class="form-group">
-                            <label for="password">Encryption Password</label>
-                            <div class="password-input-container">
-                                <input type="password" id="password" name="password" required
-                                       placeholder="Enter the encryption password shared with you separately">
-                                <button type="button" id="toggleReadPassword" class="btn btn-primary">Show</button>
+                    <form id="decryptForm" aria-busy="true" aria-describedby="decryptFormStatus">
+                        <fieldset id="decryptFormControls" class="sensitive-form-controls" disabled>
+                            <div class="form-group">
+                                <label for="password">Encryption Password</label>
+                                <div class="password-input-container">
+                                    <input type="password" id="password" required
+                                           placeholder="Enter the encryption password shared with you separately">
+                                    <button type="button" id="toggleReadPassword" class="btn btn-primary">Show</button>
+                                </div>
+                                <small class="form-help">The password should have been shared with you separately from the memo URL.</small>
                             </div>
-                            <small class="form-help">The password should have been shared with you separately from the memo URL.</small>
-                        </div>
-                        <button type="submit" class="btn btn-primary" id="decryptButton">Decrypt Memo</button>
+                            <button type="submit" class="btn btn-primary" id="decryptButton">Decrypt Memo</button>
+                        </fieldset>
+
+                        <p id="decryptFormStatus" class="form-help" role="status">Loading...</p>
+                        <noscript><p class="form-help">Requires JavaScript. Requires HTML5.</p></noscript>
 
                         <div id="decryptLoadingIndicator" class="loading-spinner hidden">
                             <div class="spinner"></div>
@@ -170,7 +175,7 @@
 
                 <div id="errorContent" class="error-content hidden">
                     <h3>Error</h3>
-                    <p id="errorMessage"></p>
+                    <p id="errorMessage">Invalid request. Please check your input and try again.</p>
                     <div class="memo-actions">
                         <a href="/en/create-memo.html" class="btn btn-primary">Create New Memo</a>
                         <a href="/en" class="btn btn-secondary">Go Home</a>

--- a/internal/frontend/generated/styles.css
+++ b/internal/frontend/generated/styles.css
@@ -655,6 +655,20 @@ button[type="submit"]:disabled {
   margin-bottom: 28px;
 }
 
+.sensitive-form-controls {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.sensitive-form-controls:disabled input,
+.sensitive-form-controls:disabled textarea,
+.sensitive-form-controls:disabled select {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 .form-group {
   margin-bottom: 22px;
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,7 @@ import (
 	"github.com/timoheimonen/securememo/internal/store"
 )
 
-const assetVersion = "20260712a"
+const assetVersion = "20260713a"
 
 var clientLocalizationAssetRe = regexp.MustCompile(`^/js/clientLocalization\.([A-Za-z0-9_-]+)\.js$`)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -490,6 +490,146 @@ func TestMemoScriptsAreVersioned(t *testing.T) {
 	}
 }
 
+func TestSensitiveMemoFormsFailClosedBeforeJavaScript(t *testing.T) {
+	app := newTestServer(t)
+	tests := []struct {
+		name          string
+		page          string
+		formID        string
+		fieldsetID    string
+		secretTagName string
+		secretID      string
+		statusID      string
+	}{
+		{
+			name:          "create",
+			page:          "create-memo.html",
+			formID:        "memoForm",
+			fieldsetID:    "memoFormControls",
+			secretTagName: "textarea",
+			secretID:      "message",
+			statusID:      "memoFormStatus",
+		},
+		{
+			name:          "read",
+			page:          "read-memo.html",
+			formID:        "decryptForm",
+			fieldsetID:    "decryptFormControls",
+			secretTagName: "input",
+			secretID:      "password",
+			statusID:      "decryptFormStatus",
+		},
+	}
+
+	for _, locale := range supportedLocales {
+		for _, tc := range tests {
+			t.Run(locale+"/"+tc.name, func(t *testing.T) {
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, "/"+locale+"/"+tc.page, nil)
+				app.ServeHTTP(rec, req)
+
+				if rec.Code != http.StatusOK {
+					t.Fatalf("GET %s status = %d, want %d", req.URL.Path, rec.Code, http.StatusOK)
+				}
+				body := rec.Body.String()
+				secretTag := htmlStartTagByID(t, body, tc.secretTagName, tc.secretID)
+				if htmlStartTagHasAttribute(secretTag, "name") {
+					t.Fatalf("GET %s secret control is natively serializable: %s", req.URL.Path, secretTag)
+				}
+
+				fieldsetTag := htmlStartTagByID(t, body, "fieldset", tc.fieldsetID)
+				if !htmlStartTagHasAttribute(fieldsetTag, "disabled") {
+					t.Fatalf("GET %s sensitive fieldset is not disabled: %s", req.URL.Path, fieldsetTag)
+				}
+
+				formTag := htmlStartTagByID(t, body, "form", tc.formID)
+				if !strings.Contains(formTag, `aria-busy="true"`) {
+					t.Fatalf("GET %s sensitive form is not initially busy: %s", req.URL.Path, formTag)
+				}
+				htmlStartTagByID(t, body, "p", tc.statusID)
+			})
+		}
+	}
+}
+
+func TestSensitiveMemoScriptsAttachSubmitGuardsBeforeEnablingForms(t *testing.T) {
+	tests := []struct {
+		name            string
+		asset           string
+		attachStatement string
+		enableStatement string
+		forbidden       string
+	}{
+		{
+			name:            "create",
+			asset:           "generated/js/create-memo.js",
+			attachStatement: "memoForm.addEventListener('submit', handleCreateSubmit);",
+			enableStatement: "memoFormControls.disabled = false;",
+		},
+		{
+			name:            "read",
+			asset:           "generated/js/read-memo.js",
+			attachStatement: "decryptForm.addEventListener('submit', handleDecryptSubmit);",
+			enableStatement: "decryptFormControls.disabled = false;",
+			forbidden:       "window.addEventListener('load'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := frontend.FS.ReadFile(tc.asset)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.asset, err)
+			}
+			source := string(body)
+			attachIndex := strings.Index(source, tc.attachStatement)
+			if attachIndex == -1 {
+				t.Fatalf("%s missing submit guard %q", tc.asset, tc.attachStatement)
+			}
+			enableIndex := strings.Index(source, tc.enableStatement)
+			if enableIndex == -1 {
+				t.Fatalf("%s missing form enablement %q", tc.asset, tc.enableStatement)
+			}
+			if attachIndex > enableIndex {
+				t.Fatalf("%s enables the sensitive form before attaching its submit guard", tc.asset)
+			}
+			if tc.forbidden != "" && strings.Contains(source, tc.forbidden) {
+				t.Fatalf("%s still delays its submit guard with %q", tc.asset, tc.forbidden)
+			}
+		})
+	}
+}
+
+func htmlStartTagByID(t *testing.T, body, tagName, id string) string {
+	t.Helper()
+	needle := `id="` + id + `"`
+	idIndex := strings.Index(body, needle)
+	if idIndex == -1 {
+		t.Fatalf("missing element %s#%s", tagName, id)
+	}
+	startIndex := strings.LastIndex(body[:idIndex], "<")
+	endOffset := strings.Index(body[idIndex:], ">")
+	if startIndex == -1 || endOffset == -1 {
+		t.Fatalf("malformed start tag for %s#%s", tagName, id)
+	}
+	tag := body[startIndex : idIndex+endOffset+1]
+	if !strings.HasPrefix(strings.ToLower(tag), "<"+strings.ToLower(tagName)) {
+		t.Fatalf("element #%s is %s, want <%s>", id, tag, tagName)
+	}
+	return tag
+}
+
+func htmlStartTagHasAttribute(tag, attribute string) bool {
+	attribute = strings.ToLower(attribute)
+	for _, field := range strings.Fields(strings.Trim(tag, "<>")) {
+		field = strings.ToLower(strings.TrimSuffix(field, "/"))
+		if field == attribute || strings.HasPrefix(field, attribute+"=") {
+			return true
+		}
+	}
+	return false
+}
+
 func TestLanguageMenuUsesRootRelativeLocaleLinks(t *testing.T) {
 	app := newTestServer(t)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- prevent plaintext memo and decryption password serialization through native GET fallback
- keep sensitive forms disabled until local submit guards and crypto capabilities are ready
- add localized fail-closed regression coverage and bump asset version to 20260713a

## Testing
- go test ./...
- go test -race ./...
- go vet ./...
- local in-app browser create, decrypt, delete, localization, and blocked-script validation